### PR TITLE
Mark this repo as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# [DEPRECATED]
+Look at https://github.com/firebug/devtools-extension-examples instead, which uses the new extension format and the `jpm` tool.
+
 Restartless-Template
 ===
 


### PR DESCRIPTION
It looks like https://github.com/firebug/devtools-extension-examples is much more up-to-date and in line with the available tutorials.